### PR TITLE
Announcements.create & Announcements.removeById

### DIFF
--- a/backend/database/announcements/__test_data__/index.js
+++ b/backend/database/announcements/__test_data__/index.js
@@ -30,5 +30,9 @@ module.exports = {
     "title": "Announcement #5",
     "content": "Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla.",
     "createdAt": new Date(Date.parse(process.env.SEED_DATE_FIVE))
+  },
+  Six: {
+    "title": "Integration Test Announcement Title",
+    "content": "Integration Test Announcement Content"
   }
 };

--- a/backend/database/announcements/__tests__/announcements.test.js
+++ b/backend/database/announcements/__tests__/announcements.test.js
@@ -5,7 +5,7 @@ const { Announcements } = require('../..');
 const testAnnouncement = require('../__test_data__');
 
 /* Unit Tests */
-describe(`Test Announcement.getAll()`, () => {
+describe(`Unit Test - Announcement.getAll()`, () => {
   test('Method returns 5 Seeder Announcements', () => {
     expect.assertions(1);
     return Announcements.getAll().then(data => {
@@ -20,7 +20,7 @@ describe(`Test Announcement.getAll()`, () => {
   });
 });
 
-describe('Test Announcements.getById( id ) with 2 different ids', () => {
+describe('Unit Test - Announcements.getById( id ) with 2 different ids', () => {
   test('Returns announcement with id = 1', () => {
     expect.assertions(1);
     return Announcements.getById(1).then(data => {
@@ -40,7 +40,7 @@ describe('Test Announcements.getById( id ) with 2 different ids', () => {
   });
 });
 
-describe('Test Announcements.getRecentByNumber( number )', () => {
+describe('Unit Test - Announcements.getRecentByNumber( number )', () => {
   test('Returns most recent Announcement', () => {
     expect.assertions(1);
     return Announcements.getRecentByNumber(1).then(data => {
@@ -63,7 +63,7 @@ describe('Test Announcements.getRecentByNumber( number )', () => {
 });
 
 /* Integration Tests */
-describe('Test Announcements.create and Announcements.remove', () => {
+describe('Integration Test - Announcements.create and Announcements.remove', () => {
   let announcementId;
 
   test('Create a fake Announcement', () => {
@@ -76,11 +76,32 @@ describe('Test Announcements.create and Announcements.remove', () => {
     });
   });
 
+  test('Get newly created Announcement and test its values', () => {
+    expect.assertions(3);
+
+    return Announcements.getById(announcementId).then( data => {
+      // data is an array that holds a single JSON object
+      expect(data[0].id).toEqual(announcementId);
+      expect(data[0].title).toEqual("Test Title");
+      expect(data[0].content).toEqual("Test Content");
+    });
+  });
+
   test('Remove the fake Announcement', () => {
     expect.assertions(1);
     return Announcements.removeById( announcementId ).then( data => {
       // No data should be returned if successful removal
       expect(data).toEqual(undefined);
     }); 
+  });
+
+  test('Confirm removal by using getById', () => {
+    expect.assertions(1);
+
+    return Announcements.getById(announcementId).then(data => {
+      // data should be an empty array, since no JSON Object of the
+      // announcement can be found or returned
+      expect(data).toEqual([])
+    });
   });
 });

--- a/backend/database/announcements/__tests__/announcements.test.js
+++ b/backend/database/announcements/__tests__/announcements.test.js
@@ -68,9 +68,9 @@ describe('Integration Test - Announcements.create and Announcements.remove', () 
 
   test('Create a fake Announcement', () => {
     expect.assertions(1);
-
     return Announcements.create(testAnnouncement.Six.title, testAnnouncement.Six.content).then(data => {
       announcementId = data[0];
+
       // We don't care what the announcementId is, just that we get one
       expect(announcementId).toEqual(announcementId);
     });
@@ -78,17 +78,19 @@ describe('Integration Test - Announcements.create and Announcements.remove', () 
 
   test('Get newly created Announcement and test its values', () => {
     expect.assertions(3);
-
     return Announcements.getById(announcementId).then( data => {
       // data is an array that holds a single JSON object
-      expect(data[0].id).toEqual(announcementId);
-      expect(data[0].title).toEqual(testAnnouncement.Six.title);
-      expect(data[0].content).toEqual(testAnnouncement.Six.content);
+      const announcement = data[0];
+
+      expect(announcement.id).toEqual(announcementId);
+      expect(announcement.title).toEqual(testAnnouncement.Six.title);
+      expect(announcement.content).toEqual(testAnnouncement.Six.content);
     });
   });
 
   test('Remove the fake Announcement', () => {
     expect.assertions(1);
+
     return Announcements.removeById( announcementId ).then( data => {
       // No data should be returned if successful removal
       expect(data).toEqual(undefined);
@@ -97,7 +99,6 @@ describe('Integration Test - Announcements.create and Announcements.remove', () 
 
   test('Confirm removal by using getById', () => {
     expect.assertions(1);
-
     return Announcements.getById(announcementId).then(data => {
       // data should be an empty array, since no JSON Object of the
       // announcement can be found or returned

--- a/backend/database/announcements/__tests__/announcements.test.js
+++ b/backend/database/announcements/__tests__/announcements.test.js
@@ -69,7 +69,7 @@ describe('Integration Test - Announcements.create and Announcements.remove', () 
   test('Create a fake Announcement', () => {
     expect.assertions(1);
 
-    return Announcements.create("Test Title", "Test Content").then( data => {
+    return Announcements.create(testAnnouncement.Six.title, testAnnouncement.Six.content).then(data => {
       announcementId = data[0];
       // We don't care what the announcementId is, just that we get one
       expect(announcementId).toEqual(announcementId);
@@ -82,8 +82,8 @@ describe('Integration Test - Announcements.create and Announcements.remove', () 
     return Announcements.getById(announcementId).then( data => {
       // data is an array that holds a single JSON object
       expect(data[0].id).toEqual(announcementId);
-      expect(data[0].title).toEqual("Test Title");
-      expect(data[0].content).toEqual("Test Content");
+      expect(data[0].title).toEqual(testAnnouncement.Six.title);
+      expect(data[0].content).toEqual(testAnnouncement.Six.content);
     });
   });
 

--- a/backend/database/announcements/__tests__/announcements.test.js
+++ b/backend/database/announcements/__tests__/announcements.test.js
@@ -61,3 +61,26 @@ describe('Test Announcements.getRecentByNumber( number )', () => {
     });
   });
 });
+
+/* Integration Tests */
+describe('Test Announcements.create and Announcements.remove', () => {
+  let announcementId;
+
+  test('Create a fake Announcement', () => {
+    expect.assertions(1);
+
+    return Announcements.create("Test Title", "Test Content").then( data => {
+      announcementId = data[0];
+      // We don't care what the announcementId is, just that we get one
+      expect(announcementId).toEqual(announcementId);
+    });
+  });
+
+  test('Remove the fake Announcement', () => {
+    expect.assertions(1);
+    return Announcements.removeById( announcementId ).then( data => {
+      // No data should be returned if successful removal
+      expect(data).toEqual(undefined);
+    }); 
+  });
+});

--- a/backend/database/announcements/create.js
+++ b/backend/database/announcements/create.js
@@ -1,0 +1,15 @@
+const Sequelize = require('sequelize');
+const db = require('../connection');
+
+// Sequel Query
+const CREATE_ANNOUNCEMENT = `INSERT INTO announcements ( title, content ) VALUES ( ?, ? );`;
+
+const create = (title, content) => {
+  return db.query(CREATE_ANNOUNCEMENT, {
+    replacements: [ title, content ],
+    type: Sequelize.QueryTypes.INSERT
+  });
+};
+
+// Export this call to the rest of the application
+module.exports = create;

--- a/backend/database/announcements/index.js
+++ b/backend/database/announcements/index.js
@@ -2,5 +2,6 @@
 module.exports = {
   getAll: require('./getAll'),
   getById: require('./getById'),
-  getRecentByNumber: require('./getRecentByNumber')
+  getRecentByNumber: require('./getRecentByNumber'),
+  create: require('./create')
 };

--- a/backend/database/announcements/index.js
+++ b/backend/database/announcements/index.js
@@ -1,7 +1,8 @@
 // Export Announcement Queries to the rest of the application
 module.exports = {
+  create: require('./create'),
   getAll: require('./getAll'),
   getById: require('./getById'),
   getRecentByNumber: require('./getRecentByNumber'),
-  create: require('./create')
+  removeById: require('./removeById')
 };

--- a/backend/database/announcements/removeById.js
+++ b/backend/database/announcements/removeById.js
@@ -1,0 +1,14 @@
+const Sequelize = require('sequelize');
+const db = require('../connection');
+
+
+const REMOVE_ANNOUNCEMENT = `DELETE FROM announcements WHERE id = ?`;
+
+const removeById = (announcement_id) => {
+  return db.query(REMOVE_ANNOUNCEMENT, {
+    replacements: [announcement_id],
+    type: Sequelize.QueryTypes.DELETE
+  });
+}; 
+
+module.exports = removeById;

--- a/backend/routes/announcements.js
+++ b/backend/routes/announcements.js
@@ -13,8 +13,23 @@ router.use((request, response, next) => {
 router.get('/', (request, response, next) => {
   Announcements.getAll().then( (result) => {
     response.status(200).json(result);
+  
   }).catch((error) => {
     response.status(400).json(error);
+  
+  });
+});
+
+router.post('/create', (request, response, next) => {
+  // TODO - Validate and Sanitize Inputs
+  const { title, content } = request.body;
+
+  Announcements.create( title, content ).then( () => {
+    response.status(201).json( { msg: `Announcement "${title}" has been saved.`});
+  
+  }).catch( (error) => {
+    response.status(400).json( { error: "New announcement was not created." } );
+  
   });
 });
 

--- a/backend/routes/announcements.js
+++ b/backend/routes/announcements.js
@@ -25,11 +25,24 @@ router.post('/create', (request, response, next) => {
   const { title, content } = request.body;
 
   Announcements.create( title, content ).then( () => {
-    response.status(201).json( { msg: `Announcement "${title}" has been saved.`});
+    response.status(201).json( { msg: `Announcement "${title}" has been saved.`} );
   
   }).catch( (error) => {
     response.status(400).json( { error: "New announcement was not created." } );
   
+  });
+});
+
+router.post('/remove/:id', (request, response, next) => {
+  // TODO - Validate and Sanitize Inputs
+
+  Announcements.removeById( request.params.id ).then( () => {
+    response.status(200).json( { msg: `Removed Announcement ID: ${request.params.id}` } );
+
+  }).catch( (error) => {
+    console.log(error);
+    response.status(400).json( { error: `Unable to remove Announcement ID: ${request.params.id}` } );
+
   });
 });
 


### PR DESCRIPTION
Created Sequelize Queries to create and remove an announcement.

Updated `routes/announcements.js` with new API calls

Added automated test that does the following
1. Create a test Announcement
2. Get the Announcement by id and compare data
3. Remove the test Announcement
4. Get the now removed Announcement by id to confirm that no data can be found

Updated test descriptions to show type of test ( ie Unit or Integration ), will change the rest of the test suite after this branch has been merged.